### PR TITLE
Resolve naming conflict with HOSTNAME default environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This document describes an approach how to create Route objects in OpenShift whi
 ## Repository Link
 Base repository link for all artefacts referenced in the following description: <https://github.com/avoigtma/openshift-certmonger>
 
->> In the remainder of the documents, all commands are executed in the 'certmonger-job' repository directory of the source repository.
+> In the remainder of the documents, all commands are executed in the 'certmonger-job' repository directory of the source repository.
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ See the template definition for the mandatory and optional parameters.
 Sample execution:
 
 ```shell
-oc process -f openshift/template.job.certmonger.yaml -p TOOL_NAMESPACE=certificate-tool -p SERVICENAME=httpd-example -p PORT=8080 -p ROUTENAME=myhttp -p ROUTETYPE=edge -p TARGET_NAMESPACE=example-ns -p HOSTNAME=bla.example.com -p JOBUUID=12345 | oc create -f -
+oc process -f openshift/template.job.certmonger.yaml -p TOOL_NAMESPACE=certificate-tool -p SERVICENAME=httpd-example -p PORT=8080 -p ROUTENAME=myhttp -p ROUTETYPE=edge -p TARGET_NAMESPACE=example-ns -p FQDN=bla.example.com -p JOBUUID=12345 | oc create -f -
 ```
 
 or using 'oc new-app' respectively.
@@ -235,7 +235,7 @@ Or use the following command line:
   * hostname myhttpd.example.com
 
 ```shell
-oc new-app routecreation-request-template -p TOOL_NAMESPACE=certificate-tool -p SERVICENAME=httpd -p PORT=8080 -p ROUTENAME=myhttp -p ROUTETYPE=edge -p TARGET_NAMESPACE=example-ns -p HOSTNAME=myhttpd.example.com
+oc new-app routecreation-request-template -p TOOL_NAMESPACE=certificate-tool -p SERVICENAME=httpd -p PORT=8080 -p ROUTENAME=myhttp -p ROUTETYPE=edge -p TARGET_NAMESPACE=example-ns -p FQDN=myhttpd.example.com
 ```
 
 

--- a/openshift/template.cm.certmonger.yaml
+++ b/openshift/template.cm.certmonger.yaml
@@ -35,7 +35,7 @@ objects:
     targetNamespace: ${TARGET_NAMESPACE}
     serviceName: ${SERVICENAME}
     routeName: ${ROUTENAME}
-    hostname: ${HOSTNAME}
+    fqdn: ${FQDN}
     port: ${PORT}
     routeType: ${ROUTETYPE}
     reencSecretName: ${REENC_CA_SECRET}
@@ -50,7 +50,7 @@ parameters:
 - name: ROUTENAME
   description: The name of the route object to be created.
   required: true
-- name: HOSTNAME
+- name: FQDN
   description: The FQDN of the route to be created. Ensure the length adheres to OpenShift / DNS conventions, i.e., max length 63 characters.
   required: true
 - name: PORT

--- a/openshift/template.job.certmonger.yaml
+++ b/openshift/template.job.certmonger.yaml
@@ -47,7 +47,7 @@ objects:
               export ROUTETYPE=${ROUTETYPE}
               export REENC_CA_SECRET=${REENC_CA_SECRET}
               export TARGET_NAMESPACE=${TARGET_NAMESPACE}
-              export HOSTNAME=${HOSTNAME}
+              export FQDN=${FQDN}
               export PORT=${PORT}
               export JOB=certmonger-${JOBUUID}
               export TOOL_NAMESPACE=${TOOL_NAMESPACE}
@@ -80,7 +80,7 @@ parameters:
 - name: ROUTENAME
   description: The name of the route object to be created.
   required: true
-- name: HOSTNAME
+- name: FQDN
   description: The FQDN of the route to be created. Ensure the length adheres to OpenShift / DNS conventions, i.e., max length 63 characters.
   required: true
 - name: PORT

--- a/podscripts/cronProcess.sh
+++ b/podscripts/cronProcess.sh
@@ -48,9 +48,9 @@ do
     ROUTENAME=$(jq -r '.data.routeName' /tmp/$APPCMNAME.json)
     ROUTETYPE=$(jq -r '.data.routeType' /tmp/$APPCMNAME.json)
     PORT=$(jq -r '.data.port' /tmp/$APPCMNAME.json)
-    HOSTNAME=$(jq -r '.data.hostname' /tmp/$APPCMNAME.json)
+    FQDN=$(jq -r '.data.fqdn' /tmp/$APPCMNAME.json)
 
-    oc new-app -n $TOOLNS job-routecreation-template -p TOOL_NAMESPACE=$TOOLNS -p SERVICENAME=$SERVICENAME -p PORT=$PORT -p ROUTENAME=$ROUTENAME -p ROUTETYPE=$ROUTETYPE -p TARGET_NAMESPACE=$TARGETNAMESPACE -p HOSTNAME=$HOSTNAME -p JOBUUID=$taskid
+    oc new-app -n $TOOLNS job-routecreation-template -p TOOL_NAMESPACE=$TOOLNS -p SERVICENAME=$SERVICENAME -p PORT=$PORT -p ROUTENAME=$ROUTENAME -p ROUTETYPE=$ROUTETYPE -p TARGET_NAMESPACE=$TARGETNAMESPACE -p FQDN=$FQDN -p JOBUUID=$taskid
     retVal=$?
     if [ $retVal -ne 0 ]; then
         err="Error ($cm): Cannot process template for creating CertMonger job. Stop processing this taks."

--- a/podscripts/runJob.sh
+++ b/podscripts/runJob.sh
@@ -2,7 +2,7 @@
 echo "Executing certificate request"
 #
 # The following environment variables are set from the pod executing this script snippet:
-# $HOSTNAME
+# $FQDN
 # $ROUTENAME
 # $ROUTETYPE
 # $SERVICENAME
@@ -13,7 +13,7 @@ echo "Executing certificate request"
 #
 # replace the commands for 'certmonger' in this section with suitable commands for accessing the PKI
 # demo only using self-signed certificate; as for selfsigned certs there is no CA, we create a dummy ca.cer file
-selfsign-getcert request -w -f /tmp/cert.crt -k /tmp/cert.key -N "CN=$HOSTNAME,OU=example.com,O=myorg" -D "$HOSTNAME" -U id-kp-serverAuth
+selfsign-getcert request -w -f /tmp/cert.crt -k /tmp/cert.key -N "CN=$FQDN,OU=example.com,O=myorg" -D "$FQDN" -U id-kp-serverAuth
 ls -l /tmp
 touch /tmp/ca.crt
 #
@@ -32,12 +32,12 @@ echo "Creating route in namespace $TARGET_NAMESPACE"
 if [ $ROUTETYPE == edge ]
 then
   echo "Creating edge route"
-  oc create route $ROUTETYPE $ROUTENAME -n $TARGET_NAMESPACE --insecure-policy=Redirect --service=$SERVICENAME --cert=$CERTFILE --key=$KEYFILE --ca-cert=$CAFILE --hostname=$HOSTNAME --port=$PORT >$MSGFILE 2>&1
+  oc create route $ROUTETYPE $ROUTENAME -n $TARGET_NAMESPACE --insecure-policy=Redirect --service=$SERVICENAME --cert=$CERTFILE --key=$KEYFILE --ca-cert=$CAFILE --hostname=$FQDN --port=$PORT >$MSGFILE 2>&1
   RES=$?
 elif [ $ROUTETYPE == passthrough ]
 then
   echo "Creating passthrough route"
-  oc create route $ROUTETYPE $ROUTENAME -n $TARGET_NAMESPACE --insecure-policy=Redirect --service=$SERVICENAME  --hostname=$HOSTNAME --port=$PORT >$MSGFILE 2>&1
+  oc create route $ROUTETYPE $ROUTENAME -n $TARGET_NAMESPACE --insecure-policy=Redirect --service=$SERVICENAME  --hostname=$FQDN --port=$PORT >$MSGFILE 2>&1
   RES=$?
 elif [ $ROUTETYPE == reencrypt ]
 then
@@ -46,7 +46,7 @@ then
   RES=$?
   if [ $RES == 0 ]
   then
-    oc create route $ROUTETYPE $ROUTENAME -n $TARGET_NAMESPACE --insecure-policy=Redirect --service=$SERVICENAME --cert=$CERTFILE --key=$KEYFILE --ca-cert=$CAFILE --dest-ca-cert=$DESTCAFILE --hostname=$HOSTNAME --port=$PORT >$MSGFILE 2>&1
+    oc create route $ROUTETYPE $ROUTENAME -n $TARGET_NAMESPACE --insecure-policy=Redirect --service=$SERVICENAME --cert=$CERTFILE --key=$KEYFILE --ca-cert=$CAFILE --dest-ca-cert=$DESTCAFILE --hostname=$FQDN --port=$PORT >$MSGFILE 2>&1
     RES=$?
   else
     ERR="$ROUTETYPE route: cannot get reencrypt cert $REENC_CA_SECRET in namespace $TARGET_NAMESPACE"

--- a/podscripts/runJob.sh
+++ b/podscripts/runJob.sh
@@ -13,6 +13,7 @@ echo "Executing certificate request"
 #
 # replace the commands for 'certmonger' in this section with suitable commands for accessing the PKI
 # demo only using self-signed certificate; as for selfsigned certs there is no CA, we create a dummy ca.cer file
+# Do not use strings with whitespaces for CN, OU or O
 selfsign-getcert request -w -f /tmp/cert.crt -k /tmp/cert.key -N "CN=$FQDN,OU=example.com,O=myorg" -D "$FQDN" -U id-kp-serverAuth
 ls -l /tmp
 touch /tmp/ca.crt

--- a/podscripts/runJob_scep-example.sh
+++ b/podscripts/runJob_scep-example.sh
@@ -9,7 +9,7 @@ echo "Executing certificate request"
 
 #
 # The following environment variables are set from the pod executing this script snippet:
-# $HOSTNAME
+# $FQDN
 # $ROUTENAME
 # $ROUTETYPE
 # $SERVICENAME
@@ -26,7 +26,7 @@ update-ca-trust
 getcert add-scep-ca -c MY-SCEP-CA -u https://scep.pki.url.example.com/my/scep/pki/uri/xyz
 sleep 16
 # retrieve the certificate via SCEP
-getcert request -I ${HOSTNAME} -c MY-SCEP-CA -N "CN=${HOSTNAME},OU=MyOrgUnitName,O=MyOrgName" -L $PKIPASSPHRASE -w -v -f /tmp/cert.crt -k /tmp/cert.key
+getcert request -I ${FQDN} -c MY-SCEP-CA -N "CN=${FQDN},OU=MyOrgUnitName,O=MyOrgName" -L $PKIPASSPHRASE -w -v -f /tmp/cert.crt -k /tmp/cert.key
 sleep 8
 #
 echo "Certificate request completed"
@@ -40,6 +40,6 @@ CERTFILE=/tmp/cert.crt
 KEYFILE=/tmp/cert.key
 echo "Creating route in namespace $TARGET_NAMESPACE"
 oc create cm -n $TARGET_NAMESPACE route-$ROUTENAME-certs --from-file=cert.cer=$CERTFILE --from-file=cert.key=$KEYFILE
-oc create route $ROUTETYPE $ROUTENAME -n $TARGET_NAMESPACE --service=$SERVICENAME --cert=$CERTFILE --key=$KEYFILE --hostname=$HOSTNAME --port=$PORT
+oc create route $ROUTETYPE $ROUTENAME -n $TARGET_NAMESPACE --service=$SERVICENAME --cert=$CERTFILE --key=$KEYFILE --hostname=$FQDN --port=$PORT
 echo "Route created"
 #

--- a/podscripts/runJob_scep-example.sh
+++ b/podscripts/runJob_scep-example.sh
@@ -26,6 +26,7 @@ update-ca-trust
 getcert add-scep-ca -c MY-SCEP-CA -u https://scep.pki.url.example.com/my/scep/pki/uri/xyz
 sleep 16
 # retrieve the certificate via SCEP
+# Do not use strings with whitespaces for CN, OU or O
 getcert request -I ${FQDN} -c MY-SCEP-CA -N "CN=${FQDN},OU=MyOrgUnitName,O=MyOrgName" -L $PKIPASSPHRASE -w -v -f /tmp/cert.crt -k /tmp/cert.key
 sleep 8
 #


### PR DESCRIPTION
The `HOSTNAME` environment variable gets overwritten if a pod is started with `oc debug` which as result will cause the pod to request a different certificate than the pod that was run without `oc debug`. Also the documentation in several parts has been improved.